### PR TITLE
Alteração CSS para fixar o footer no final da página.

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -235,6 +235,11 @@ p {
 } */
 
 .rodape {
+    position: fixed;
+    bottom: 0px;
+    left: 0px;
+    width: 100vw;
+    padding: 10px;
     text-align: center;
     font-family: var(--fonte-texto);
     font-size: 12px;


### PR DESCRIPTION
Inclusão do trecho abaixo para garantir a fixação do footer, com a estilização correta, no final da página, independente do tamanho da tela utilizada:
```
.rodape{
    position: fixed;
    bottom: 0px;
    left: 0px;
    width: 100vw;
    padding: 10px;
    ...
}
```