### PR TITLE
Position do footer alterado de ```fixed```para ```static``` para se manter no final da página, não sobrepondo a lista de compras.

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -235,7 +235,7 @@ p {
 } */
 
 .rodape {
-    position: fixed;
+    position: static;
     bottom: 0px;
     left: 0px;
     width: 100vw;


### PR DESCRIPTION
Position do footer alterado de ```fixed```para ```static``` para se manter no final da página, não sobrepondo a lista de compras.


![image](https://github.com/user-attachments/assets/ed9c51d3-2735-4970-8b13-1bfaa10fb5e3)
